### PR TITLE
Integer: force amount to be an integer and not a string

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,9 +22,9 @@
 
     <div class="fluid-container">
         <div class="panel panel-default">
-            <div class="panel-body">		
+            <div class="panel-body">
 				<div class="row">
-					
+
 					<div class="col-xs-4 coin-container">
 						<div class="left">
 							<div class="coin">
@@ -51,12 +51,13 @@
 												<option value='nmc' data-image='images/coins/namecoin.png'>Namecoin</option>
 												<option value='ftc' data-image='images/coins/feathercoin.png'>Feathercoin</option>
 												<option value='bc' data-image='images/coins/blackcoin.png'>Blackcoin</option>
-											</select>							
+											</select>
 										</div>
 									</div>
 									<div class="col-xs-5 amount">
 										<div class="form-item">
-											<input type="text" class="form-control disabled" id="amount" placeholder="Amount (optional)">
+											<input type="integer" class="form-control disabled" id="amount" placeholder="Amount (optional)"
+                        oninput="this.value = this.value.replace(/[^0-9.]/g, ''); this.value = this.value.replace(/(\..*)\./g, '$1');">
 										</div>
 									</div>
 								</div>
@@ -117,7 +118,7 @@
 								<p></p>
 							</div>
 						</div>
-					</div>	
+					</div>
             </div>
         </div>
         <p class="payment-footer" style="text-align:right;">Powered by ShapeShift.io <img width="40" style="position:relative;top:-3px;" class="logo" src="images/lens_icon.png"></p>
@@ -140,6 +141,3 @@
 	<script src="js/payment.js" type="text/javascript"></script>
 </body>
 </html>
-
-
-


### PR DESCRIPTION
## Issue

The amount (optional) of should be restricted to an integer. At the moment it can be a string. 
A basic FE validation should be provided.

## Steps to Reproduce

Enter a string the optional amount and click on submit. The redirection happens. 

## Expected Behavior

Do not type anything in the amount field if text is being typed. 

